### PR TITLE
Fix Heroku mLab connectionString

### DIFF
--- a/test/app.js
+++ b/test/app.js
@@ -6,12 +6,8 @@ module.exports = function(app)
 
     var connectionString = 'mongodb://127.0.0.1:27017/test';
 
-    if(process.env.MLAB_USERNAME) {
-        connectionString = process.env.MLAB_USERNAME + ":" +
-            process.env.MLAB_PASSWORD + "@" +
-            process.env.MLAB_HOST + ':' +
-            process.env.MLAB_PORT + '/' +
-            process.env.MLAB_APP_NAME;
+    if(process.env.MONGODB_URI) {
+        connectionString = process.env.MONGODB_URI;
     }
 
     var mongoose = require("mongoose");


### PR DESCRIPTION
When adding mLab add-on to Heroku. Heroku config sets 'MONGODB_URI' variable that incorporates all parts of the mongodb URI. No need to dissect into different app_name, host, password, port, and username